### PR TITLE
Implement atomic binary trees

### DIFF
--- a/examples/multithreading_safe.py
+++ b/examples/multithreading_safe.py
@@ -1,0 +1,96 @@
+"""Example to show atomic trees are thread-safe."""
+import threading
+import sys
+
+from typing import List, Union
+
+from forest.binary_trees import atomic_trees
+from forest.binary_trees import traversal
+
+
+TreeType = Union[
+    atomic_trees.AVLTree,
+    atomic_trees.BinarySearchTree,
+    atomic_trees.DoubleThreadedBinaryTree,
+    atomic_trees.RBTree,
+]
+
+sys.setswitchinterval(0.0000001)
+
+
+def insert_data(tree: TreeType, data: List) -> None:
+    """Insert data into a tree."""
+    for key in data:
+        tree.insert(key=key, data=str(key))
+
+
+def multithreading_simulator(tree: TreeType) -> None:
+    """Use five threads to insert data into a tree with non-duplicate data."""
+    try:
+        thread1 = threading.Thread(
+            target=insert_data, args=(tree, [item for item in range(100)])
+        )
+        thread2 = threading.Thread(
+            target=insert_data, args=(tree, [item for item in range(100, 200)])
+        )
+        thread3 = threading.Thread(
+            target=insert_data, args=(tree, [item for item in range(200, 300)])
+        )
+        thread4 = threading.Thread(
+            target=insert_data, args=(tree, [item for item in range(300, 400)])
+        )
+        thread5 = threading.Thread(
+            target=insert_data, args=(tree, [item for item in range(400, 500)])
+        )
+
+        thread1.start()
+        thread2.start()
+        thread3.start()
+        thread4.start()
+        thread5.start()
+
+        thread1.join()
+        thread2.join()
+        thread3.join()
+        thread4.join()
+        thread5.join()
+
+        if isinstance(tree, atomic_trees.AVLTree) or isinstance(
+            tree, atomic_trees.BinarySearchTree
+        ):
+            result = [item for item in traversal.inorder_traverse(tree=tree)]
+        else:
+            result = [item for item in tree.inorder_traverse()]
+
+        incorrect_node_list = list()
+        for index in range(len(result)):
+            if index > 0:
+                if result[index] < result[index - 1]:
+                    incorrect_node_list.append(
+                        f"{result[index - 1]} -> {result[index]}"
+                    )
+
+        if len(result) != 500 or len(incorrect_node_list) > 0:
+            print(f"  total_nodes: {len(result)}")
+            print(f"  incorrect_order: {incorrect_node_list}")
+    except:  # noqa: 1722
+        print("  Tree built incorrectly.")
+
+
+if __name__ == "__main__":
+
+    print("Atomic AVL Tree:")
+    avlt = atomic_trees.AVLTree()
+    multithreading_simulator(tree=avlt)
+
+    print("Atomic Binary Search Tree:")
+    bst = atomic_trees.BinarySearchTree()
+    multithreading_simulator(tree=bst)
+
+    print("Atomic Double Threaded Binary Search Tree:")
+    double_threaded = atomic_trees.DoubleThreadedBinaryTree()
+    multithreading_simulator(tree=double_threaded)
+
+    print("Atomic Red-Black Tree:")
+    rbt = atomic_trees.RBTree()
+    multithreading_simulator(tree=rbt)

--- a/forest/binary_trees/atomic_trees.py
+++ b/forest/binary_trees/atomic_trees.py
@@ -1,0 +1,130 @@
+# Copyright © 2021 by Shun Huang. All rights reserved.
+# Licensed under MIT License.
+# See LICENSE in the project root for license information.
+
+"""Thread-safe trees."""
+
+import threading
+
+from typing import Any, Optional
+
+from forest import metrics
+from forest.binary_trees import avl_tree
+from forest.binary_trees import binary_search_tree
+from forest.binary_trees import double_threaded_binary_tree
+from forest.binary_trees import red_black_tree
+from forest.binary_trees import single_threaded_binary_trees
+
+
+class AVLTree(avl_tree.AVLTree):
+    """Thread-safe AVL Tree."""
+
+    def __init__(self, registry: Optional[metrics.MetricRegistry] = None) -> None:
+        avl_tree.AVLTree.__init__(self, registry=registry)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            avl_tree.AVLTree.insert(self, key=key, data=data)
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            avl_tree.AVLTree.delete(self, key=key)
+
+
+class BinarySearchTree(binary_search_tree.BinarySearchTree):
+    """Thread-safe Binary Search Tree."""
+
+    def __init__(self, registry: Optional[metrics.MetricRegistry] = None) -> None:
+        binary_search_tree.BinarySearchTree.__init__(self, registry=registry)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            binary_search_tree.BinarySearchTree.insert(self, key=key, data=data)
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            binary_search_tree.BinarySearchTree.delete(self, key=key)
+
+
+class RBTree(red_black_tree.RBTree):
+    """Thread-safe Red-Black Tree."""
+
+    def __init__(self, registry: Optional[metrics.MetricRegistry] = None) -> None:
+        red_black_tree.RBTree.__init__(self, registry=registry)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            red_black_tree.RBTree.insert(self, key=key, data=data)
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            red_black_tree.RBTree.delete(self, key=key)
+
+
+class DoubleThreadedBinaryTree(double_threaded_binary_tree.DoubleThreadedBinaryTree):
+    """Thread-safe Double Threaded Binary Search Tree."""
+
+    def __init__(self) -> None:
+        double_threaded_binary_tree.DoubleThreadedBinaryTree.__init__(self)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            double_threaded_binary_tree.DoubleThreadedBinaryTree.insert(
+                self, key=key, data=data
+            )
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            double_threaded_binary_tree.DoubleThreadedBinaryTree.delete(self, key=key)
+
+
+class LeftThreadedBinaryTree(single_threaded_binary_trees.LeftThreadedBinaryTree):
+    """Thread-safe Left Threaded Binary Search Tree."""
+
+    def __init__(self) -> None:
+        single_threaded_binary_trees.LeftThreadedBinaryTree.__init__(self)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            single_threaded_binary_trees.LeftThreadedBinaryTree.insert(
+                self, key=key, data=data
+            )
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            single_threaded_binary_trees.LeftThreadedBinaryTree.delete(self, key=key)
+
+
+class RightThreadedBinaryTree(single_threaded_binary_trees.RightThreadedBinaryTree):
+    """Thread-safe Right Threaded Binary Search Tree."""
+
+    def __init__(self) -> None:
+        single_threaded_binary_trees.RightThreadedBinaryTree.__init__(self)
+        self._lock = threading.Lock()
+
+    def insert(self, key: Any, data: Any) -> None:
+        """Thread-safe insert."""
+        with self._lock:
+            single_threaded_binary_trees.RightThreadedBinaryTree.insert(
+                self, key=key, data=data
+            )
+
+    def delete(self, key: Any) -> None:
+        """Thread-safe delete."""
+        with self._lock:
+            single_threaded_binary_trees.RightThreadedBinaryTree.delete(self, key=key)

--- a/forest/binary_trees/red_black_tree.py
+++ b/forest/binary_trees/red_black_tree.py
@@ -94,12 +94,12 @@ class RBTree:
 
     def __repr__(self) -> str:
         """Provie the tree representation to visualize its layout."""
-        if self.root:
-            return (
-                f"{type(self)}, root={self.root}, "
-                f"tree_height={str(self.get_height(self.root))}"
-            )
-        return "empty tree"
+        if (self.root is None) or (self.root == self._NIL):
+            return "empty tree"
+        return (
+            f"{type(self)}, root={self.root}, "
+            f"tree_height={str(self.get_height(self.root))}"
+        )
 
     @property
     def empty(self) -> bool:
@@ -109,7 +109,7 @@ class RBTree:
         -----
         The property, `empty`, is read-only.
         """
-        return self.root is self._NIL
+        return (self.root is None) or (self.root == self._NIL)
 
     def search(self, key: Any) -> Optional[Node]:
         """Look for a node by a given key.

--- a/forest/binary_trees/single_threaded_binary_trees.py
+++ b/forest/binary_trees/single_threaded_binary_trees.py
@@ -180,7 +180,8 @@ class RightThreadedBinaryTree:
 
             # Case 2a: only one left child
             elif deleting_node.left and (
-                deleting_node.is_thread or deleting_node.right is None
+                deleting_node.is_thread
+                or deleting_node.right is None
                 # deleting_node.right is None means the deleting node is the root.
             ):
                 predecessor = self.get_predecessor(node=deleting_node)
@@ -574,7 +575,8 @@ class LeftThreadedBinaryTree:
 
             # Case 2b: only one right child
             elif deleting_node.right and (
-                deleting_node.is_thread or deleting_node.left is None
+                deleting_node.is_thread
+                or deleting_node.left is None
                 # deleting_node.left is None means the deleting node is the root.
             ):
                 successor = self.get_successor(node=deleting_node)

--- a/forest/binary_trees/single_threaded_binary_trees.py
+++ b/forest/binary_trees/single_threaded_binary_trees.py
@@ -185,7 +185,9 @@ class RightThreadedBinaryTree:
                 )
 
             # Case 2b: only one left child
-            elif deleting_node.left and deleting_node.is_thread:
+            elif deleting_node.left and (
+                deleting_node.is_thread or deleting_node.right is None
+            ):
                 predecessor = self.get_predecessor(node=deleting_node)
                 if predecessor:
                     predecessor.right = deleting_node.right
@@ -564,7 +566,9 @@ class LeftThreadedBinaryTree:
                 self._transplant(deleting_node=deleting_node, replacing_node=None)
 
             # Case 2a: only one right child
-            elif deleting_node.right and deleting_node.is_thread:
+            elif deleting_node.right and (
+                deleting_node.is_thread or deleting_node.left is None
+            ):
                 successor = self.get_successor(node=deleting_node)
                 if successor:
                     successor.left = deleting_node.left

--- a/forest/binary_trees/single_threaded_binary_trees.py
+++ b/forest/binary_trees/single_threaded_binary_trees.py
@@ -178,21 +178,22 @@ class RightThreadedBinaryTree:
             ):
                 self._transplant(deleting_node=deleting_node, replacing_node=None)
 
-            # Case 2a: only one right child
-            elif deleting_node.left is None and deleting_node.is_thread is False:
-                self._transplant(
-                    deleting_node=deleting_node, replacing_node=deleting_node.right
-                )
-
-            # Case 2b: only one left child
+            # Case 2a: only one left child
             elif deleting_node.left and (
                 deleting_node.is_thread or deleting_node.right is None
+                # deleting_node.right is None means the deleting node is the root.
             ):
                 predecessor = self.get_predecessor(node=deleting_node)
                 if predecessor:
                     predecessor.right = deleting_node.right
                 self._transplant(
                     deleting_node=deleting_node, replacing_node=deleting_node.left
+                )
+
+            # Case 2b: only one right child
+            elif deleting_node.left is None and deleting_node.is_thread is False:
+                self._transplant(
+                    deleting_node=deleting_node, replacing_node=deleting_node.right
                 )
 
             # Case 3: two children
@@ -565,21 +566,22 @@ class LeftThreadedBinaryTree:
             ):
                 self._transplant(deleting_node=deleting_node, replacing_node=None)
 
-            # Case 2a: only one right child
+            # Case 2a: only one left child
+            elif (deleting_node.right is None) and (deleting_node.is_thread is False):
+                self._transplant(
+                    deleting_node=deleting_node, replacing_node=deleting_node.left
+                )
+
+            # Case 2b: only one right child
             elif deleting_node.right and (
                 deleting_node.is_thread or deleting_node.left is None
+                # deleting_node.left is None means the deleting node is the root.
             ):
                 successor = self.get_successor(node=deleting_node)
                 if successor:
                     successor.left = deleting_node.left
                 self._transplant(
                     deleting_node=deleting_node, replacing_node=deleting_node.right
-                )
-
-            # Case 2b: only one left left child
-            elif (deleting_node.right is None) and (deleting_node.is_thread is False):
-                self._transplant(
-                    deleting_node=deleting_node, replacing_node=deleting_node.left
                 )
 
             # Case 3: two children

--- a/tests/test_atomic_trees.py
+++ b/tests/test_atomic_trees.py
@@ -1,0 +1,118 @@
+"""Unit tests for atomic trees."""
+import sys
+import threading
+
+from typing import List, Union
+
+from forest.binary_trees import atomic_trees
+from forest.binary_trees import traversal
+
+
+sys.setswitchinterval(0.0000001)
+
+
+TreeType = Union[
+    atomic_trees.AVLTree,
+    atomic_trees.BinarySearchTree,
+    atomic_trees.DoubleThreadedBinaryTree,
+    atomic_trees.LeftThreadedBinaryTree,
+    atomic_trees.RBTree,
+    atomic_trees.RightThreadedBinaryTree,
+]
+
+
+def insert_data(tree: TreeType, data: List) -> None:
+    """Insert data into a tree."""
+    for key in data:
+        tree.insert(key=key, data=str(key))
+
+
+def multithreading_simulator(tree: TreeType) -> bool:
+    """Use five threads to insert data into a tree with non-duplicate data."""
+    thread1 = threading.Thread(
+        target=insert_data, args=(tree, [item for item in range(100)])
+    )
+    thread2 = threading.Thread(
+        target=insert_data, args=(tree, [item for item in range(100, 200)])
+    )
+    thread3 = threading.Thread(
+        target=insert_data, args=(tree, [item for item in range(200, 300)])
+    )
+    thread4 = threading.Thread(
+        target=insert_data, args=(tree, [item for item in range(300, 400)])
+    )
+    thread5 = threading.Thread(
+        target=insert_data, args=(tree, [item for item in range(400, 500)])
+    )
+
+    thread1.start()
+    thread2.start()
+    thread3.start()
+    thread4.start()
+    thread5.start()
+
+    thread1.join()
+    thread2.join()
+    thread3.join()
+    thread4.join()
+    thread5.join()
+
+    if isinstance(tree, atomic_trees.LeftThreadedBinaryTree):
+        result = [item for item in tree.reverse_inorder_traverse()]
+        for index in range(len(result)):
+            if index > 0:
+                if result[index] > result[index - 1]:
+                    return False
+    else:
+        if isinstance(tree, atomic_trees.AVLTree) or isinstance(
+            tree, atomic_trees.BinarySearchTree
+        ):
+            result = [item for item in traversal.inorder_traverse(tree=tree)]
+        else:
+            result = [item for item in tree.inorder_traverse()]
+
+        for index in range(len(result)):
+            if index > 0:
+                if result[index] < result[index - 1]:
+                    return False
+
+    if len(result) != 500:
+        return False
+
+    return True
+
+
+def test_atomic_avl_tree():
+    """Test if atomic AVL tree is thread-safe."""
+    tree = atomic_trees.AVLTree()
+    assert multithreading_simulator(tree=tree) is True
+
+
+def test_atomic_binary_search_tree():
+    """Test if atomic binary search tree is thread-safe."""
+    tree = atomic_trees.BinarySearchTree()
+    assert multithreading_simulator(tree=tree) is True
+
+
+def test_atomic_double_threaded_tree():
+    """Test if atomic double threaded tree is thread-safe."""
+    tree = atomic_trees.DoubleThreadedBinaryTree()
+    assert multithreading_simulator(tree=tree) is True
+
+
+def test_atomic_red_black_tree():
+    """Test if atomic red-black tree is thread-safe."""
+    tree = atomic_trees.RBTree()
+    assert multithreading_simulator(tree=tree) is True
+
+
+def test_atomic_left_threaded_tree():
+    """Test if atomic left threaded tree is thread-safe."""
+    tree = atomic_trees.LeftThreadedBinaryTree()
+    assert multithreading_simulator(tree=tree)
+
+
+def test_atomic_right_threaded_tree():
+    """Test if atomic right threaded tree is thread-safe."""
+    tree = atomic_trees.RightThreadedBinaryTree()
+    assert multithreading_simulator(tree=tree)

--- a/tests/test_atomic_trees.py
+++ b/tests/test_atomic_trees.py
@@ -27,8 +27,14 @@ def insert_data(tree: TreeType, data: List) -> None:
         tree.insert(key=key, data=str(key))
 
 
+def delete_data(tree: TreeType, data: List) -> None:
+    """Delete data from a tree."""
+    for key in data:
+        tree.delete(key=key)
+
+
 def multithreading_simulator(tree: TreeType) -> bool:
-    """Use five threads to insert data into a tree with non-duplicate data."""
+    """Use five threads to insert and delete with non-duplicate data."""
     thread1 = threading.Thread(
         target=insert_data, args=(tree, [item for item in range(100)])
     )
@@ -78,6 +84,37 @@ def multithreading_simulator(tree: TreeType) -> bool:
 
     if len(result) != 500:
         return False
+
+    thread1 = threading.Thread(
+        target=delete_data, args=(tree, [item for item in range(100)])
+    )
+    thread2 = threading.Thread(
+        target=delete_data, args=(tree, [item for item in range(100, 200)])
+    )
+    thread3 = threading.Thread(
+        target=delete_data, args=(tree, [item for item in range(200, 300)])
+    )
+    thread4 = threading.Thread(
+        target=delete_data, args=(tree, [item for item in range(300, 400)])
+    )
+    thread5 = threading.Thread(
+        target=delete_data, args=(tree, [item for item in range(400, 500)])
+    )
+
+    thread1.start()
+    thread2.start()
+    thread3.start()
+    thread4.start()
+    thread5.start()
+
+    thread1.join()
+    thread2.join()
+    thread3.join()
+    thread4.join()
+    thread5.join()
+
+    if not tree.empty:
+        False
 
     return True
 

--- a/tests/test_avl_tree.py
+++ b/tests/test_avl_tree.py
@@ -317,3 +317,24 @@ def test_metrics(basic_tree):
 
     assert registry.get_metric(name="avlt.rotate").count
     assert registry.get_metric(name="avlt.height").report()
+
+
+def test_empty():
+    """Test AVL becomes empty."""
+    tree = avl_tree.AVLTree()
+
+    for key in range(10):
+        tree.insert(key=key, data=str(key))
+
+    for key in range(10):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+    for key in reversed(range(10)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(10)):
+        tree.delete(key=key)
+
+    assert tree.empty

--- a/tests/test_binary_search_tree.py
+++ b/tests/test_binary_search_tree.py
@@ -52,3 +52,24 @@ def test_metrics(basic_tree):
         tree.insert(key=key, data=data)
 
     assert registry.get_metric(name="bst.height").report()
+
+
+def test_empty():
+    """Test a tree becomes empty."""
+    tree = binary_search_tree.BinarySearchTree()
+
+    for key in range(10):
+        tree.insert(key=key, data=str(key))
+
+    for key in range(10):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+    for key in reversed(range(10)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(10)):
+        tree.delete(key=key)
+
+    assert tree.empty

--- a/tests/test_double_threaded_binary_tree.py
+++ b/tests/test_double_threaded_binary_tree.py
@@ -204,3 +204,24 @@ def test_deletion_double_threaded_case(basic_tree):
         (4, "4"),
         (1, "1"),
     ] == [item for item in tree.reverse_inorder_traverse()]
+
+
+def test_empty():
+    """Test a double threaded tree becomes empty."""
+    tree = double_threaded_binary_tree.DoubleThreadedBinaryTree()
+
+    for key in range(10):
+        tree.insert(key=key, data=str(key))
+
+    for key in range(10):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+    for key in reversed(range(10)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(10)):
+        tree.delete(key=key)
+
+    assert tree.empty

--- a/tests/test_red_black_tree.py
+++ b/tests/test_red_black_tree.py
@@ -108,7 +108,7 @@ def test_deletion(basic_tree):
     ]
 
 
-def test_deletion_no_child(basic_tree):
+def test_deletion_no_child():
     """Test the deletion of a red black tree."""
     tree = red_black_tree.RBTree()
 
@@ -125,7 +125,7 @@ def test_deletion_no_child(basic_tree):
     ]
 
 
-def test_deletion_one_child(basic_tree):
+def test_deletion_one_child():
     """Test the deletion of a red black tree."""
     tree = red_black_tree.RBTree()
 
@@ -154,7 +154,7 @@ def test_deletion_one_child(basic_tree):
     ]
 
 
-def test_deletion_two_children(basic_tree):
+def test_deletion_two_children():
     """Test the deletion of a red black tree."""
     tree = red_black_tree.RBTree()
 
@@ -265,3 +265,24 @@ def test_metrics(basic_tree):
 
     assert registry.get_metric(name="rbt.rotate").count
     assert registry.get_metric(name="rbt.height").report()
+
+
+def test_empty():
+    """Test red-black becomes empty."""
+    tree = red_black_tree.RBTree()
+
+    for key in range(10):
+        tree.insert(key=key, data=str(key))
+
+    for key in range(10):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+    for key in reversed(range(10)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(10)):
+        tree.delete(key=key)
+
+    assert tree.empty

--- a/tests/test_single_threaded_binary_trees.py
+++ b/tests/test_single_threaded_binary_trees.py
@@ -136,6 +136,19 @@ def test_deletion_right_threaded_case(basic_tree):
     ] == [item for item in tree.inorder_traverse()]
 
 
+def test_deletion_right_threaded_empty():
+    """Test deletion when right threaded binary tree is a chain and becomes empty."""
+    tree = single_threaded_binary_trees.RightThreadedBinaryTree()
+
+    for key in reversed(range(2)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(2)):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+
 def test_simple_left_threaded_case(basic_tree):
     """Test the basic opeartions of a left threaded binary search tree."""
     tree = single_threaded_binary_trees.LeftThreadedBinaryTree()
@@ -287,3 +300,24 @@ def test_deletion_left_threaded_case_2():
         (2, "2"),
         (1, "1"),
     ] == [item for item in tree.reverse_inorder_traverse()]
+
+
+def test_deletion_left_threaded_empty():
+    """Test deletion when left threaded binary tree is a chain and becomes empty."""
+    tree = single_threaded_binary_trees.LeftThreadedBinaryTree()
+
+    for key in range(10):
+        tree.insert(key=key, data=str(key))
+
+    for key in range(10):
+        tree.delete(key=key)
+
+    assert tree.empty
+
+    for key in reversed(range(10)):
+        tree.insert(key=key, data=str(key))
+
+    for key in reversed(range(10)):
+        tree.delete(key=key)
+
+    assert tree.empty


### PR DESCRIPTION
Implement atomic binary trees.
Fix bugs:
- incorrect RBTree empty condition
- incorrect deletion case 2 (i.e., only one child) on both single-threaded trees